### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -218,7 +218,7 @@ export default {
 
         $stopMeteor () {
           // Stop all reactivity when view is destroyed.
-          this._trackerHandles.forEach((tracker) => {
+          this._trackerHandles && this._trackerHandles.forEach((tracker) => {
             try {
               tracker.stop()
             } catch (e) {


### PR DESCRIPTION

![vue-meteor-tracker-bug](https://user-images.githubusercontent.com/1429030/44303067-4da06780-a34c-11e8-88b8-790d8ca03fba.JPG)
fix bug: TypeError: Cannot read property 'forEach' of null
    at VueComponent.$stopMeteor