### PR TITLE
Don't initialize $lazy meteor props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,20 +75,13 @@ export default {
     }
 
     function proxyData () {
-      const initData = this.$_meteorInitData = {}
-      let meteor = this.$options.meteor
+      const meteor = this.$options.meteor
 
       if (meteor) {
         // Reactive data
         for (let key in meteor) {
           if (key.charAt(0) !== '$') {
             proxyKey.call(this, key)
-
-            const func = meteor[key]
-
-            if (meteor.$lazy && typeof func === 'function') {
-              initData[key] = getResult(func.call(this))
-            }
           }
         }
       }
@@ -139,7 +132,7 @@ export default {
       data () {
         return {
           $meteor: {
-            data: this.$_meteorInitData,
+            data: {},
             subs: {},
           },
         }


### PR DESCRIPTION
Fixes #49 (partially)

For now, `meteor` properties marked as `$lazy` are not really lazy, because the functions are executed at least once in order to fill `vm.$data.$meteor.data` with initial values. It seems impossible to completely prevent execution without [workarounds](https://github.com/meteor-vue/vue-meteor-tracker/issues/49#issuecomment-452880298).

This PR proposes to get rid of values initialization at all. Defined `meteor` properties will be still proxied and therefore available in the component and template with `undefined` values. Running `this.$startMeteor()` will add actual values.

I understand that this change may easily breaks many existing apps based on the current `$lazy` behavior. A possible alternative is adding another special property to `meteor` object, like `$noInit` or something similar. Developer then can use both `$lazy` and `$noInit` or stay with the first one. Or, let's say, `$veryLasy` property which does the whole job. I can create a PR with this functionality.