### PR TITLE
fixed #29 (1st issue)

### DIFF
--- a/src/vue-plugin.js
+++ b/src/vue-plugin.js
@@ -182,6 +182,9 @@ export default {
                 stop () {},
               }
             } else { */
+              if (!this._trackerHandles) {
+                throw new Error('$subscribe called on destroyed or uninitialized component');
+              }
               const key = args[0];
               const oldSub = this._subs[key]
               let handle = Vue.config.meteor.subscribe.apply(this, args);


### PR DESCRIPTION
+ Cannot read property 'push' of null

Throwing an exception with a more helpful description when attempting to call `$subscribe` on a destroyed component.